### PR TITLE
Improve Clearing Tags Utility

### DIFF
--- a/core/cooggerapp/models/content.py
+++ b/core/cooggerapp/models/content.py
@@ -14,7 +14,7 @@ from core.cooggerapp.choices import languages, make_choices, status_choices
 from .category import Category
 from .topic import Topic
 from .userextra import OtherAddressesOfUsers, OtherInformationOfUsers
-from .utils import get_new_hash
+from .utils import get_new_hash, format_tags
 from .utopic import UTopic
 
 
@@ -256,22 +256,9 @@ class Content(models.Model):
         return beneficiaries
 
     def ready_tags(self, limit=5):
-        def clearly_tags(get_tag):
-            clearly_tags = []
-            tags = ""
-            for i in get_tag:
-                if i not in clearly_tags:
-                    clearly_tags.append(i)
-            for i in clearly_tags:
-                if i == clearly_tags[-1]:
-                    tags += slugify(i.lower())
-                else:
-                    tags += slugify(i.lower()) + " "
-            return tags
-
         get_tag = self.tags.split(" ")[:limit]
         get_tag.insert(0, "coogger")
-        return clearly_tags(get_tag)
+        return format_tags(get_tag)
 
     @property
     def get_commits(self):  # to api

--- a/core/cooggerapp/models/content.py
+++ b/core/cooggerapp/models/content.py
@@ -3,6 +3,7 @@ from difflib import HtmlDiff
 from django.contrib.auth.models import User
 from django.db import models
 from django.utils.timezone import now
+from django.utils.text import slugify
 from django_md_editor.models import EditorMdField
 
 from bs4 import BeautifulSoup

--- a/core/cooggerapp/models/utils.py
+++ b/core/cooggerapp/models/utils.py
@@ -1,8 +1,12 @@
 from hashlib import sha256
 from uuid import uuid4
+from django.utils.text import slugify
 
 __all__ = ["get_new_hash"]
 
 
 def get_new_hash():
     return sha256(str(uuid4().hex).encode("utf-8")).hexdigest()
+
+def format_tags(tags):
+    return " ".join({slugify(tag.lower()) for tag in tags})


### PR DESCRIPTION
`Content` modelinde kullanılan ve tagları unique hale getirip sonrasında ise onları tekrardan bir araya getiren fonksiyon şuydu;
```py
def clearly_tags(get_tag):
    clearly_tags = []
    tags = ""
    for i in get_tag:
        if i not in clearly_tags:
            clearly_tags.append(i)
    for i in clearly_tags:
        if i == clearly_tags[-1]:
            tags += slugify(i.lower())
        else:
            tags += slugify(i.lower()) + " "
    return tags
```

Burada ilk iterasyonda bütün tagların üstünden geçiliyor ve eğer o tag listede yoksa listeye ekleniyor (uniquify the list) sonrasında da son taga kadar taglar aralarında bir boşluk olacak şekilde ekleniyordu.

Uniquification olayında en pratik çözüm setlerdir (kümeler). Bir iterable'ı set'e çevirdiğiniz zaman python otomatik olarak duplicate elementleri yokeder çünkü bir kümede aynı elementten iki tane bulunmaz. `set([1, 2, 1, 3]) == {1, 2, 3}`

İkinci olay ise `str.join` methodudur. `join` bir iterable'ı alır ve arasına verilen stringi ekleyerek onu başka bir stringe çevirir. Örneğin `" ".join(["batuhan", "osman"]) == "batuhan osman"` veya `" ve ".join(["batuhan", "osman", "taşkaya"]) == "batuhan ve osman ve taşkaya"`

Bu patch bu iki güzellekten faydalanarak yukarıdaki fonksiyonu şuna çeviriyor, ayrıca bunu da `utils.py`'a koyarak function bodysini arındırıyor.
```py
def format_tags(tags):
    return " ".join({slugify(tag.lower()) for tag in tags})
```